### PR TITLE
Run on filesystems which are not case-sensitive

### DIFF
--- a/backstop_history/BackstopHistory.py
+++ b/backstop_history/BackstopHistory.py
@@ -384,7 +384,7 @@ class BackstopHistory(object):
                              in ofls directory that represents the  built load.
                                 -  list of dictionary items
         """
-        backstop_file_path = globfile(os.path.join(oflsdir, 'CR*.backstop'))
+        backstop_file_path = globfile(os.path.join(oflsdir, 'CR[0-9]*.backstop'))
 
         self.logger.info("GET_BS_CMDS - Using backstop file %s" % backstop_file_path)
 


### PR DESCRIPTION
## Description

This PR allows for backstop_history to be used on case-insensitive filesystems (e.g. Windows) by refining the glob for backstop files to avoid finding the `cr_test.backstop` file. 

## Testing

- [x] Passes unit tests on macOS and Windows
- [x] Functional testing
