### PR TITLE
Remove unnecessary and incorrectly applied round off

### DIFF
--- a/backstop_history/BackstopHistory.py
+++ b/backstop_history/BackstopHistory.py
@@ -146,7 +146,7 @@ class Backstop_History_Class(object):
 
         self.logger = logger
 
-        self.logger.debug('LOGGER ************************* BHC Init    VO VERSION' )
+        self.logger.debug('LOGGER ************************* BHC Init' )
 
         self.outdir = outdir
 
@@ -458,13 +458,14 @@ class Backstop_History_Class(object):
         """
         self.logger.debug('--------------------ASSEMBLING HISTORY. BACKSTOP LIST IS: %s' %  (self.backstop_file_list))
 
-        # Convert tbegin to cxcsec if necessary
+        # Convert tbegin to cxcsec if necessary; have both DOY string and
+        # cxcsec available.
         if isinstance(tbegin, str):
 
-            tbegin_time = round(Time(tbegin, format = 'yday', scale = 'utc').cxcsec,1)
+            tbegin_time = Time(tbegin, format = 'yday', scale = 'utc').cxcsec
         else:
             tbegin_time =tbegin
-            tbegin = round(Time(tbegin_time, format = 'cxcsec', scale = 'utc').yday, 1)
+            tbegin = Time(tbegin_time, format = 'cxcsec', scale = 'utc').yday
 
         self.logger.debug('\nTBEGIN_DATE IS: %s, TEBEGIN TIME IS: %s' % (tbegin, tbegin_time))
 

--- a/backstop_history/Release_Notes_V3.0.1.txt
+++ b/backstop_history/Release_Notes_V3.0.1.txt
@@ -1,0 +1,56 @@
+﻿
+Release Notes for Version 3.0.1 of Backstop History
+
+
+
+Change Description
+==================
+
+tbegin is used by backstop_History to know how far back in time to backchain loads.
+tbegin is supplied by the user of backstop_History. The Assemble_History method
+generated both a DOY and Chandra Seconds version of that time, and rounded the
+time off. Rounding is unnecessary and was incorrectly applied in one instance.
+The incorrect application did not affect the operation of the program as it was 
+done only for logger purposes.
+
+Also the initial logger comment under "debug" was modified.
+
+
+Comments were added or modified for clarification.
+
+
+Files Changed:
+============== 
+
+https://github.com/acisops/backstop_history/pull/23
+
+
+
+
+Testing:
+======== 
+
+Unit and functional testing completed to assure that the
+assembled histories were unchanged from previous runs.
+
+
+
+Interface impacts
+=================
+
+None.
+
+
+Review
+====== 
+
+Objectives and Results by ACIS Ops
+
+
+Deployment Plan
+===============
+
+Installation of Backstop History will occur once approved by FSDS.
+
+
+

--- a/backstop_history/Release_Notes_V3.0.1.txt
+++ b/backstop_history/Release_Notes_V3.0.1.txt
@@ -6,8 +6,8 @@ Release Notes for Version 3.0.1 of Backstop History
 Change Description
 ==================
 
-tbegin is used by backstop_History to know how far back in time to backchain loads.
-tbegin is supplied by the user of backstop_History. The Assemble_History method
+tbegin is used by backstop_history to know how far back in time to backchain loads.
+tbegin is supplied by the user of backstop_history. The Assemble_History method
 generated both a DOY and Chandra Seconds version of that time, and rounded the
 time off. Rounding is unnecessary and was incorrectly applied in one instance.
 The incorrect application did not affect the operation of the program as it was 


### PR DESCRIPTION
## Description
Removed the round off of tbegin as it's not needed (run_start fix will alleviate the need for it) and it was incorrectly applied in one instance.


## Testing

- [x ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x ] Functional testing

Fixes #